### PR TITLE
Fixing bad table name error

### DIFF
--- a/code/cms/model/customer/Customer.php
+++ b/code/cms/model/customer/Customer.php
@@ -330,12 +330,12 @@ class Customer extends Member {
 		/**
 		 * On /dev/build, create the Customers group - if it doesn't exist yet.
 		 */
-		$count = new SQLQuery("COUNT(*)");
-		$count->setFrom("`group`")->addWhere("(`Title` = 'Customers')");
-		$count = $count->execute()->value(); 
-		if( $count < 1 ) {
+		$exists = Group::get()->filter(array(
+			'Title' => 'Customers',
+		))->exists();
+		if( $exists ) {
 			
-			$n = new Group();
+			$n = Group::create();
 			
 			$n->Title = "Customers";
 			$n->Description = "Security group for store customers";


### PR DESCRIPTION
Fix an issue where SQL error is thrown on dev/build due to incorrect table casing:

```
Couldn't run query: SELECT COUNT(*) FROM `group` WHERE ((`Title` = 'Customers')) Table 'group' doesn't exist
```

Note the table should be `Group` with a capital "G"